### PR TITLE
Use e.composedPath() instead of e.path in showImage

### DIFF
--- a/mastodon-on-blog.js
+++ b/mastodon-on-blog.js
@@ -53,7 +53,7 @@
   }
   function showImage (e, imageData) {
     e.preventDefault()
-    e.path[1].innerHTML = imageData.reduce((a, b) =>
+    e.composedPath()[1].innerHTML = imageData.reduce((a, b) =>
       b.type === 'image'
         ? a + `
           <div class="image-wrapper">


### PR DESCRIPTION
Hi,

First, thanks for this great widget, I'm using it now in my website!
The button to show images didn't work, and it seems that one needs to use e.composedPath() instead of e.path, since it's not standard: https://chromestatus.com/feature/5726124632965120

Cheers,
Miguel